### PR TITLE
Changes to calculation of temperature-dependent elastic constants

### DIFF
--- a/iprPy/calculation/elastic_constants_dynamic/born_matrix.template
+++ b/iprPy/calculation/elastic_constants_dynamic/born_matrix.template
@@ -31,14 +31,13 @@ fix langevin all langevin ${temperature} ${temperature} $(100.0*dt) ${randomseed
 thermo_style custom step temp pe press
 run ${equilsteps}
 
-# Define stress tensor compute
-compute stress all pressure thermo_temp
+# Define virial contribution to the pressure compute
+compute virial all pressure NULL virial
 
 # Define born matrix compute
-compute virial all pressure NULL virial
 compute born all born/matrix numdiff ${strainrange} virial
 
-thermo_style custom step temp pe press c_stress[*] c_born[*]
+thermo_style custom step temp pe press c_virial[*] c_born[*]
 thermo_modify format float %.13e
 
 run ${runsteps}

--- a/iprPy/calculation/elastic_constants_dynamic/elastic_constants_dynamic.py
+++ b/iprPy/calculation/elastic_constants_dynamic/elastic_constants_dynamic.py
@@ -193,26 +193,26 @@ def build_Cij_fluc(thermo, N, T, V, lammps_units):
     Constructs the fluctuation component of the Cij calculation from the LAMMPS
     stress (i.e. pressure) outputs.
     
-        C_fluc = V / (kB T) * ( <σ_i σ_j> - <σ_i> <σ_j> )
+        C_fluc = - V / (kB T) * ( <σ_i σ_j> - <σ_i> <σ_j> )
     """
     # Switch for 0K
     if T == 0:
         return np.zeros((6,6))
     
-    # Extract all stress values 
+    # Extract the virial contributions to the stress tensor 
     σ = uc.set_in_units(np.array([
-        thermo['c_stress[1]'].values,
-        thermo['c_stress[2]'].values,
-        thermo['c_stress[3]'].values,
-        thermo['c_stress[4]'].values,
-        thermo['c_stress[5]'].values,
-        thermo['c_stress[6]'].values]), lammps_units['pressure'])
+        -thermo['c_virial[1]'].values,
+        -thermo['c_virial[2]'].values,
+        -thermo['c_virial[3]'].values,
+        -thermo['c_virial[4]'].values,
+        -thermo['c_virial[5]'].values,
+        -thermo['c_virial[6]'].values]), lammps_units['pressure'])
 
-    # Compute the stress fluctuation term
+    # Compute the virial stress fluctuation term
     fluc = np.empty((6,6))
     for i in range(6):
         for j in range(6):
-            fluc[i,j] = - (σ[i] * σ[j]).mean() - (σ[i].mean() * σ[j].mean())
+            fluc[i,j] = - ((σ[i] * σ[j]).mean() - (σ[i].mean() * σ[j].mean()))
     
     # Multipy by V / (kb T) 
     kB = uc.unit['kB']


### PR DESCRIPTION
Changing born_matrix.template to only output the virial contribution of the pressure tensor, and changing elastic_constants_dynamic.py to account for the previous change, as well as fixing the sign of the stress and fluctuation terms.